### PR TITLE
Pass options to NodeCache as object.

### DIFF
--- a/lib/wundergrounded.js
+++ b/lib/wundergrounded.js
@@ -21,7 +21,7 @@ module.exports = function(debug) {
     var stdTtl = secondsInCache || 300;
     var checkperiod = secondsBetweenChecks || 30;
     if(debug) log('Enabling results cache; seconds in cache = ' + stdTtl + ', seconds between eviction checks = ' + checkperiod + '.');
-    _cache = new NodeCache(stdTtl, checkperiod);
+    _cache = new NodeCache({ stdTTL: stdTtl, checkperiod: checkperiod });
     return this;
   };
 


### PR DESCRIPTION
NodeCache expects its options to come in the form of an object.
See https://www.npmjs.com/package/node-cache

The options were previously being ignored, which resulted in indefinite
caching of API responses.
